### PR TITLE
Switch endianess of ct id to match upstream

### DIFF
--- a/dict.c
+++ b/dict.c
@@ -544,7 +544,8 @@ EXPORT_SYMBOL(seq_print_bool);
 
 void seq_print_integer(struct seq_file *m, char *buf)
 {
-	seq_printf(m, "int: %u", *(int *)buf);
+	uint32_t temp = *(uint32_t *)buf;
+	seq_printf(m, "int: %u", ntohl(temp));
 }
 EXPORT_SYMBOL(seq_print_integer);
 
@@ -616,6 +617,7 @@ static int write_dict(struct file *file, char *buf, size_t size)
 						pr_err("%s: Opt_key_int failed %d\n", __func__, ret);
 						goto free_local_buf;
 					}
+					temp = htonl(temp);
 					key_len = sizeof(temp);
 					memcpy(key, &temp, key_len);
 					key_printfn = &seq_print_integer;
@@ -901,6 +903,7 @@ static int read_id_write(struct file *file, char *buf, size_t size)
 						pr_err("%s: Opt_key_int failed %d\n", __func__, ret);
 						goto free_local_buf;
 					}
+					temp = htonl(temp);
 					key_len = sizeof(temp);
 					memcpy(key, &temp, key_len);
 					break;
@@ -1035,6 +1038,7 @@ static int delete_write(struct file *file, char *buf, size_t size)
 						pr_err("%s: Opt_key_int failed %d\n", __func__, ret);
 						goto free_local_buf;
 					}
+					temp = htonl(temp);
 					key_len = sizeof(temp);
 					memcpy(key, &temp, key_len);
 					break;

--- a/nft_dict.c
+++ b/nft_dict.c
@@ -303,7 +303,7 @@ static void nft_ctid_get_eval(const struct nft_expr *expr, struct nft_regs *regs
 	if (!ct)
 		ct_id = 0;
 	else
-		ct_id = htonl(nf_ct_get_id(ct));
+		ct_id = nf_ct_get_id(ct);
 #else
 	ct_id = (unsigned long)ct;
 #endif


### PR DESCRIPTION
The upstream NFT_CT_ID key returns the value without
the htonl, so match that here

MFW-1115